### PR TITLE
Update Guac Source from 1.2 to 1.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN git clone https://github.com/mike-jumper/guacamole-legacy-urls.git
 WORKDIR /workdir/guacamole-legacy-urls
 RUN mvn package
 
-
-FROM oznu/guacamole
+FROM jwetzell/guacamole
 
 RUN apt-get update && apt-get install -y netcat vim
 


### PR DESCRIPTION
Hey @amochtar, for when you return...

Our guac image is almost 3 years outdated now. This is a simple update, Ive tested it [with this image](https://hub.docker.com/repository/docker/jpelchat/instruqt-guacamole/general), it works great. No changes needed configuration wise that Ive experienced. 

Valuable update for general improvements (perhaps placebo, but it seems faster!), but also this bug fix, which Ive experienced: https://issues.apache.org/jira/browse/GUACAMOLE-1687
