### PR TITLE
Use a maintained AIO Guac container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,8 @@ RUN git clone https://github.com/mike-jumper/guacamole-legacy-urls.git
 WORKDIR /workdir/guacamole-legacy-urls
 RUN mvn package
 
+FROM jwetzell/guacamole
 
-FROM oznu/guacamole
-
-RUN apt-get update && apt-get install -y netcat vim
+RUN apt-get update && apt-get install -y vim
 
 COPY --from=build /workdir/guacamole-legacy-urls/target/guacamole-legacy-urls-*.jar /app/guacamole/extensions/


### PR DESCRIPTION
`s/oznu/jwetzell` and remove netcat (since it should already be there)